### PR TITLE
Add DynamicPin

### DIFF
--- a/examples/gpio_dynamic.rs
+++ b/examples/gpio_dynamic.rs
@@ -1,0 +1,51 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_rtt_target;
+
+use lpc8xx_hal::{
+    cortex_m_rt::entry, gpio::Level, pins::DynamicPinDirection, Peripherals,
+};
+
+#[entry]
+fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
+    // Get access to the device's peripherals. Since only one instance of this
+    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // If we tried to call the method a second time, it would return `None`, but
+    // we're only calling it the one time here, so we can safely `unwrap` the
+    // `Option` without causing a panic.
+    let p = Peripherals::take().unwrap();
+
+    // Initialize the APIs of the peripherals we need.
+    #[cfg(feature = "82x")]
+    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    #[cfg(feature = "845")]
+    let gpio = {
+        let mut syscon = p.SYSCON.split();
+        p.GPIO.enable(&mut syscon.handle)
+    };
+
+    // Select pin for LED
+    #[cfg(feature = "82x")]
+    let (led, token) = (p.pins.pio0_12, gpio.tokens.pio0_12);
+    #[cfg(feature = "845")]
+    let (led, token) = (p.pins.pio1_1, gpio.tokens.pio1_1);
+
+    // Configure the LED pin as dynamic, with its initial direction being Input.
+    // A dynamic pin can change ist direction at runtime, but will not give you the same
+    //  compile-time guarantees a unidirectinal pin gives you.
+    let mut led =
+        led.into_dynamic_pin(token, Level::Low, DynamicPinDirection::Input);
+
+    // Blink the LED by toggling the pin direction
+    loop {
+        for _ in 0..10_000 {
+            led.switch_to_output(Level::Low);
+        }
+        for _ in 0..10_000 {
+            led.switch_to_input();
+        }
+    }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -487,6 +487,54 @@ where
 
         set_low::<T>(&registers);
     }
+
+    /// Indicates whether the pin output is currently set to HIGH
+    ///
+    /// TODO add detailed docs
+    pub fn is_set_high(&self) -> bool {
+        // TODO check pin direction first! i.e. only read if pin is in Output mode
+
+        // TODO this is copypasta from Output s impl, unify?
+        // This is sound, as we only read a bit from a register.
+        let gpio = unsafe { &*pac::GPIO::ptr() };
+        let registers = Registers::new(gpio);
+
+        registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+    }
+
+    /// Indicates whether the pin output is currently set to LOW
+    ///
+    /// TODO add detailed docs
+    pub fn is_set_low(&self) -> bool {
+        // TODO check pin direction first! i.e. only read if pin is in Output mode
+
+        !self.is_set_high()
+    }
+
+    /// Indicates wether the signal *read at* the pin input is HIGH
+    ///
+    /// TODO add detailed docs
+    pub fn is_high(&self) -> bool {
+        // TODO check pin direction first! i.e. only read if pin is in Input mode
+        // TODO this is copypasta from Input s impl, unify?
+
+        // This is sound, as we only do a stateless write to a bit that no other
+        // `GpioPin` instance writes to.
+        let gpio = unsafe { &*pac::GPIO::ptr() };
+        let registers = Registers::new(gpio);
+
+        registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+    }
+
+    /// Indicates wether the pin input is LOW
+    ///
+    /// TODO add detailed docs
+    pub fn is_low(&self) -> bool {
+        // TODO check pin direction first! i.e. only read if pin is in Input mode
+        // TODO this is copypasta from Input s impl, unify?
+
+        !self.is_high()
+    }
 }
 
 impl<T> OutputPin for GpioPin<T, direction::Dynamic>
@@ -506,7 +554,37 @@ where
     }
 }
 
-// TODO add impls for InputPin (and others?) for dynamic
+impl<T> StatefulOutputPin for GpioPin<T, direction::Dynamic>
+where
+    T: pins::Trait,
+{
+    fn is_set_high(&self) -> Result<bool, Self::Error> {
+        // Call the inherent method defined above.
+        Ok(self.is_set_high())
+    }
+
+    fn is_set_low(&self) -> Result<bool, Self::Error> {
+        // Call the inherent method defined above.
+        Ok(self.is_set_low())
+    }
+}
+
+impl<T> InputPin for GpioPin<T, direction::Dynamic>
+where
+    T: pins::Trait,
+{
+    type Error = Void;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        // Call the inherent method defined above.
+        Ok(self.is_high())
+    }
+
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        // Call the inherent method defined above.
+        Ok(self.is_low())
+    }
+}
 
 impl<T> InputPin for GpioPin<T, direction::Input>
 where

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -423,6 +423,19 @@ where
     pub fn toggle_direction(&self) {
         todo!()
     }
+
+    /// TODO add docs
+    /// TODO ensure this can only be called in a valid state?
+    pub fn set_high(&mut self) {
+        // TODO copypasta from output; refactor into shared fn
+
+        // This is sound, as we only do a stateless write to a bit that no other
+        // `GpioPin` instance writes to.
+        let gpio = unsafe { &*pac::GPIO::ptr() };
+        let registers = Registers::new(gpio);
+
+        set_high::<T>(&registers);
+    }
 }
 
 impl<T> OutputPin for GpioPin<T, direction::Dynamic>
@@ -432,7 +445,8 @@ where
     type Error = Void;
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        todo!()
+        // Call the inherent method defined above.
+        Ok(self.set_high())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -495,15 +495,14 @@ where
         set_low::<T>(&registers);
     }
 
-    /// Indicates whether the pin output is currently set to HIGH
+    /// Indicates whether the voltage at this pin is currently set to HIGH
+    /// This can be used when the pin is in any direction:
+    ///
+    /// If it is currently an Output pin, it indicates whether the pin output is set to HIGH
+    /// If it is currently an Input pin, it indicates wether the pin input is HIGH
     ///
     /// TODO add detailed docs
-    /// always returns false if current pin direction is Input
-    pub fn is_set_high(&self) -> bool {
-        if self._direction.is_output == false {
-            return false;
-        }
-
+    pub fn is_high(&self) -> bool {
         // TODO this is copypasta from Output s impl, unify?
         // This is sound, as we only read a bit from a register.
         let gpio = unsafe { &*pac::GPIO::ptr() };
@@ -512,45 +511,12 @@ where
         registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
     }
 
-    /// Indicates whether the pin output is currently set to LOW
+    /// Indicates whether the voltage at this pin is currently set to LOW
+    /// This can be used when the pin is in any direction:
     ///
-    /// always returns false if current pin direction is Input
-    pub fn is_set_low(&self) -> bool {
-        if self._direction.is_output == false {
-            return false;
-        }
-
-        !self.is_set_high()
-    }
-
-    /// Indicates wether the signal *read at* the pin input is HIGH
-    ///
-    /// TODO add detailed docs
-    /// always returns false if current pin direction is Output
-    pub fn is_high(&self) -> bool {
-        if self._direction.is_output {
-            return false;
-        }
-
-        // TODO this is copypasta from Input s impl, unify?
-
-        // This is sound, as we only do a stateless write to a bit that no other
-        // `GpioPin` instance writes to.
-        let gpio = unsafe { &*pac::GPIO::ptr() };
-        let registers = Registers::new(gpio);
-
-        registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
-    }
-
-    /// Indicates wether the pin input is LOW
-    ///
-    /// TODO add detailed docs
-    /// always returns false if current pin direction is Output
+    /// If it is currently an Output pin, it indicates whether the pin output is set to LOW
+    /// If it is currently an Input pin, it indicates wether the pin input is LOW
     pub fn is_low(&self) -> bool {
-        if self._direction.is_output {
-            return false;
-        }
-
         !self.is_high()
     }
 }
@@ -594,7 +560,7 @@ where
         match self._direction.is_output {
             true => {
                 // Call the inherent method defined above.
-                Ok(self.is_set_high())
+                Ok(self.is_high())
             }
             false => Err(Self::Error::WrongDirection),
         }
@@ -604,7 +570,7 @@ where
         match self._direction.is_output {
             true => {
                 // Call the inherent method defined above.
-                Ok(self.is_set_low())
+                Ok(self.is_low())
             }
             false => Err(Self::Error::WrongDirection),
         }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -277,7 +277,7 @@ where
         let gpio = unsafe { &*pac::GPIO::ptr() };
         let registers = Registers::new(gpio);
 
-        registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+        is_high::<T>(&registers)
     }
 
     /// Indicates wether the pin input is LOW
@@ -376,7 +376,7 @@ where
         let gpio = unsafe { &*pac::GPIO::ptr() };
         let registers = Registers::new(gpio);
 
-        registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+        is_high::<T>(&registers)
     }
 
     /// Indicates whether the pin output is currently set to LOW
@@ -508,7 +508,7 @@ where
         let gpio = unsafe { &*pac::GPIO::ptr() };
         let registers = Registers::new(gpio);
 
-        registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+        is_high::<T>(&registers)
     }
 
     /// Indicates whether the voltage at this pin is currently set to LOW
@@ -516,6 +516,7 @@ where
     ///
     /// If it is currently an Output pin, it indicates whether the pin output is set to LOW
     /// If it is currently an Input pin, it indicates wether the pin input is LOW
+    /// TODO add detailed docs
     pub fn is_low(&self) -> bool {
         !self.is_high()
     }
@@ -559,7 +560,7 @@ where
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         match self._direction.is_output {
             true => {
-                // Call the inherent method defined above.
+                // Re-use level reading function
                 Ok(self.is_high())
             }
             false => Err(Self::Error::WrongDirection),
@@ -569,7 +570,7 @@ where
     fn is_set_low(&self) -> Result<bool, Self::Error> {
         match self._direction.is_output {
             true => {
-                // Call the inherent method defined above.
+                // Re-use level reading function
                 Ok(self.is_low())
             }
             false => Err(Self::Error::WrongDirection),
@@ -742,6 +743,10 @@ fn set_high<T: pins::Trait>(registers: &Registers) {
 
 fn set_low<T: pins::Trait>(registers: &Registers) {
     registers.clr[T::PORT].write(|w| unsafe { w.clrp().bits(T::MASK) });
+}
+
+fn is_high<T: pins::Trait>(registers: &Registers) -> bool {
+    registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
 }
 
 // For internal use only.

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -225,7 +225,6 @@ where
         // Since all other instances of `GpioPin` are doing the same, there are
         // no race conditions.
         let gpio = unsafe { &*pac::GPIO::ptr() };
-
         let registers = Registers::new(gpio);
         let direction = D::switch::<T>(&registers, arg);
 
@@ -503,7 +502,6 @@ where
     ///
     /// TODO add detailed docs
     pub fn is_high(&self) -> bool {
-        // TODO this is copypasta from Output s impl, unify?
         // This is sound, as we only read a bit from a register.
         let gpio = unsafe { &*pac::GPIO::ptr() };
         let registers = Registers::new(gpio);
@@ -899,7 +897,7 @@ pub mod direction {
         pub(super) is_output: bool,
     }
 
-    /// TODO add docs
+    /// Error that can be thrown by operations on a Dynamic pin
     #[derive(Copy, Clone)]
     pub enum DynamicPinErr {
         /// you called a function that is not applicable to the pin's current direction

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -418,12 +418,12 @@ impl<T> GpioPin<T, direction::Dynamic>
 where
     T: pins::Trait,
 {
-    /// Tell us whether this pin's direction is cuirrently set to Output.
+    /// Tell us whether this pin's direction is currently set to Output.
     pub fn direction_is_output(&self) -> bool {
         return self._direction.is_output;
     }
 
-    /// Tell us whether this pin's direction is cuirrently set to Input.
+    /// Tell us whether this pin's direction is currently set to Input.
     pub fn direction_is_input(&self) -> bool {
         return !self._direction.is_output;
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -319,6 +319,9 @@ where
         }
     }
 
+    // TODO: should a fn into_dynamic(initial_direction: direction)
+    // be added here and in impl<T> GpioPin<T, direction::Input>?
+
     /// Set the pin output to HIGH
     ///
     /// This method is only available, if two conditions are met:
@@ -423,7 +426,7 @@ where
         return self._direction.is_output;
     }
 
-    /// Tell us whether this pin's direction is currently set to Input.
+    /// Tell us whether this pin's direction is cuirrently set to Input.
     pub fn direction_is_input(&self) -> bool {
         return !self._direction.is_output;
     }
@@ -500,7 +503,9 @@ where
     /// If it is currently an Output pin, it indicates whether the pin output is set to HIGH
     /// If it is currently an Input pin, it indicates wether the pin input is HIGH
     ///
-    /// TODO add detailed docs
+    /// This method is only available, if the pin is in the GPIO state.
+    /// See [`Pin::into_dynamic_pin`].
+    /// Unless this condition is met, code trying to call this method will not compile.
     pub fn is_high(&self) -> bool {
         // This is sound, as we only read a bit from a register.
         let gpio = unsafe { &*pac::GPIO::ptr() };
@@ -514,7 +519,10 @@ where
     ///
     /// If it is currently an Output pin, it indicates whether the pin output is set to LOW
     /// If it is currently an Input pin, it indicates wether the pin input is LOW
-    /// TODO add detailed docs
+    ///
+    /// This method is only available, if the pin is in the GPIO state.
+    /// See [`Pin::into_dynamic_pin`].
+    /// Unless this condition is met, code trying to call this method will not compile.
     pub fn is_low(&self) -> bool {
         !self.is_high()
     }

--- a/src/mrt.rs
+++ b/src/mrt.rs
@@ -1,4 +1,4 @@
-//! API for the MRT peripheral
+//! API for the MRT (Multi-Rate Timer) peripheral
 //!
 //! Please be aware that this doesn't try to abstract everything, it only
 //! implements the embedded-hal `Timer` functionality.

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -11,4 +11,6 @@ mod traits;
 
 pub mod state;
 
-pub use self::{gen::*, pin::Pin, state::State, traits::Trait};
+pub use self::{
+    gen::*, pin::DynamicPinDirection, pin::Pin, state::State, traits::Trait,
+};

--- a/src/pins/gen.rs
+++ b/src/pins/gen.rs
@@ -54,6 +54,8 @@ macro_rules! pins {
             #[allow(non_camel_case_types)]
             pub struct $type(());
 
+            // note to self: turn constants into getters/setters so I can change the values at runtime
+            // create new dynamictoken that takes ownership of strongly typed one and creates new dyn
             impl Trait for $type {
                 const PORT: usize = $port;
                 const ID  : u8    = $id;

--- a/src/pins/gen.rs
+++ b/src/pins/gen.rs
@@ -54,8 +54,6 @@ macro_rules! pins {
             #[allow(non_camel_case_types)]
             pub struct $type(());
 
-            // note to self: turn constants into getters/setters so I can change the values at runtime
-            // create new dynamictoken that takes ownership of strongly typed one and creates new dyn
             impl Trait for $type {
                 const PORT: usize = $port;
                 const ID  : u8    = $id;

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -175,6 +175,15 @@ pub struct Pin<T: Trait, S: State> {
     pub(crate) _state: S,
 }
 
+/// Marks the current directin of a Dynamic Pin.
+pub enum DynamicPinDirection {
+    /// Pin is currently Input
+    Input,
+
+    /// Pin is currently Output
+    Output,
+}
+
 impl<T> Pin<T, state::Unused>
 where
     T: Trait,
@@ -347,10 +356,10 @@ where
     pub fn into_dynamic_pin(
         self,
         token: Token<T, init_state::Enabled>,
-        initial: Level,
+        level: Level,
+        direction: DynamicPinDirection,
     ) -> GpioPin<T, direction::Dynamic> {
-        // TODO: pass an initial direction too!
-        GpioPin::new(token, initial)
+        GpioPin::new(token, (level, direction))
     }
 
     /// Transition pin to SWM mode

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -286,6 +286,15 @@ where
         GpioPin::new(token, initial)
     }
 
+    /// TODO add docs
+    pub fn into_dynamic_pin(
+        self,
+        token: Token<T, init_state::Enabled>,
+        initial: Level,
+    ) -> GpioPin<T, direction::Dynamic> {
+        GpioPin::new(token, initial)
+    }
+
     /// Transition pin to SWM mode
     ///
     /// This method is only available while the pin is in the unused state. Code

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -176,7 +176,7 @@ pub struct Pin<T: Trait, S: State> {
 }
 
 /// Marks the current directin of a Dynamic Pin.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum DynamicPinDirection {
     /// Pin is currently Input
     Input,
@@ -317,6 +317,7 @@ where
     ///     prelude::*,
     ///     Peripherals,
     ///     gpio,
+    ///     pins
     /// };
     ///
     /// let p = Peripherals::take().unwrap();
@@ -333,6 +334,7 @@ where
     /// let mut pin = p.pins.pio0_12.into_dynamic_pin(
     ///     gpio.tokens.pio0_12,
     ///     gpio::Level::Low,
+    ///     pins::DynamicPinDirection::Input,
     /// );
     ///
     /// // Direction can now be switched

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -286,12 +286,70 @@ where
         GpioPin::new(token, initial)
     }
 
-    /// TODO add docs
+    /// Transition pin to Dynamic mode, i.e. GPIO direction switchable at runtime
+    ///
+    /// This method is only available while the pin is in the unused state. Code
+    /// that attempts to call this method while the pin is in any other state
+    /// will not compile. See [State Management] for more information on
+    /// managing pin states.
+    ///
+    /// Consumes this `Pin` instance and returns an instance of [`GpioPin`],
+    /// which provides access to all GPIO functions.
+    ///
+    /// This method requires a GPIO token from the [`GPIO`] struct, to ensure
+    /// that the GPIO peripheral is enabled, and stays enabled while the pin is
+    /// in the GPIO mode.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use lpc8xx_hal::{
+    ///     prelude::*,
+    ///     Peripherals,
+    ///     gpio,
+    /// };
+    ///
+    /// let p = Peripherals::take().unwrap();
+    ///
+    /// let mut syscon = p.SYSCON.split();
+    /// let swm = p.SWM.split();
+    ///
+    /// #[cfg(feature = "82x")]
+    /// let gpio = p.GPIO;
+    /// #[cfg(feature = "845")]
+    /// let gpio = p.GPIO.enable(&mut syscon.handle);
+    ///
+    /// // Transition pin into GPIO state, then set it to output
+    /// let mut pin = p.pins.pio0_12.into_dynamic_pin(
+    ///     gpio.tokens.pio0_12,
+    ///     gpio::Level::Low,
+    /// );
+    ///
+    /// // Direction can now be switched
+    /// pin.switch_to_input();
+    ///
+    /// // in/output pin functions are available while pin has the matching direction
+    /// let is_high = pin.is_high()
+    /// let is_low = pin.is_low()
+    ///
+    /// pin.switch_to_output(gpio::Level::Low);
+    /// pin.set_high();
+    /// pin.set_low();
+    ///
+    /// // pin direction can be queried
+    /// let is_input = pin.direction_is_input();
+    /// let is_output = pin.direction_is_output();
+    /// ```
+    ///
+    /// [State Management]: #state-management
+    /// [`GpioPin`]: ../gpio/struct.GpioPin.html
+    /// [`GPIO`]: ../gpio/struct.GPIO.html
     pub fn into_dynamic_pin(
         self,
         token: Token<T, init_state::Enabled>,
         initial: Level,
     ) -> GpioPin<T, direction::Dynamic> {
+        // TODO: pass an initial direction too!
         GpioPin::new(token, initial)
     }
 

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -176,6 +176,7 @@ pub struct Pin<T: Trait, S: State> {
 }
 
 /// Marks the current directin of a Dynamic Pin.
+#[derive(Debug, PartialEq)]
 pub enum DynamicPinDirection {
     /// Pin is currently Input
     Input,

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -329,8 +329,8 @@ where
     /// pin.switch_to_input();
     ///
     /// // in/output pin functions are available while pin has the matching direction
-    /// let is_high = pin.is_high()
-    /// let is_low = pin.is_low()
+    /// let is_high = pin.is_high();
+    /// let is_low = pin.is_low();
     ///
     /// pin.switch_to_output(gpio::Level::Low);
     /// pin.set_high();


### PR DESCRIPTION
As far as I know you and @ jamesmunns have already talked about this, but maybe it makes sense to discuss this without a proxy: This PR adds a `DynamicPin` which can change direction at runtime. I've also taken the liberty to refactor some duplicate code into helpers.

There's still a lot of room for future improvement (The specific Pin of each Dynamic Pins is still baked into its type which makes it hard to make Pin Handling in the Test-Adapter more generic), but maybe that's for the next iteration :)

Opening this as Draft PR in your repo to get your feedback before I rock up to the upstream repo with a change that nobody may want.
Also, as you can see, there are still open questions (marked with `TODO` comments) on which I'd be interested in what you think.

(obviously I'd be happy to squash before merging)